### PR TITLE
Fix then_else macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,14 +194,25 @@ for i in 1..10 {
 		.then!{ w += i * i }
 		.then_else!{ w += 1 };
 }
-assert_eq!(w, 181);
+assert_eq!(w, 72);
 # }
 ```
 */
 #[macro_export]
 macro_rules! then_else {
-	($v:tt, $($body:tt)*) => {
-		$v {
+	({ then! ( $cond:expr, $($if_body:tt)* ) }, $($body:tt)*) => {
+		if $cond {
+			$($if_body)*
+		}
+		else {
+			$($body)*
+		}
+	};
+	({ then! { $cond:expr, $($if_body:tt)* } }, $($body:tt)*) => {
+		if $cond {
+			$($if_body)*
+		}
+		else {
 			$($body)*
 		}
 	};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,16 +203,14 @@ macro_rules! then_else {
 	({ then! ( $cond:expr, $($if_body:tt)* ) }, $($body:tt)*) => {
 		if $cond {
 			$($if_body)*
-		}
-		else {
+		} else {
 			$($body)*
 		}
 	};
 	({ then! { $cond:expr, $($if_body:tt)* } }, $($body:tt)*) => {
 		if $cond {
 			$($if_body)*
-		}
-		else {
+		} else {
 			$($body)*
 		}
 	};

--- a/tests/builtin.rs
+++ b/tests/builtin.rs
@@ -1,0 +1,63 @@
+use postfix_macros::{match_or, postfix_macros, then, then_else, unwrap_or};
+
+postfix_macros! {
+    #[test]
+    fn builtin_unwrap_or() {
+        let mut check = false;
+
+        None.unwrap_or!(check = true);
+        assert!(check);
+
+        Some(()).unwrap_or!(check = false);
+        assert!(check);
+    }
+}
+
+postfix_macros! {
+    #[test]
+    fn builtin_match_or() {
+        let mut check_match = false;
+        let mut check_default = true;
+
+        true.match_or!(true => check_match = true; check_default = false);
+        assert!(check_match);
+        assert!(check_default);
+
+        check_default = false;
+
+        true.match_or!(false => check_match = false; check_default = true);
+        assert!(check_match);
+        assert!(check_default);
+    }
+}
+
+postfix_macros! {
+    #[test]
+    fn builtin_then() {
+        let mut check = false;
+
+        true.then!(check = true);
+        assert!(check);
+
+        false.then!(check = false);
+        assert!(check);
+    }
+}
+
+postfix_macros! {
+    #[test]
+    fn builtin_then_else() {
+        let mut check_then = false;
+        let mut check_else = true;
+
+        true.then!(check_then = true).then_else!(check_else = false);
+        assert!(check_then);
+        assert!(check_else);
+
+        check_else = false;
+
+        false.then!(check_then = false).then_else!(check_else = true);
+        assert!(check_then);
+        assert!(check_else);
+    }
+}

--- a/tests/builtin.rs
+++ b/tests/builtin.rs
@@ -17,16 +17,17 @@ postfix_macros! {
     #[test]
     fn builtin_match_or() {
         let mut check_match = false;
-        let mut check_default = true;
+        let mut check_default = false;
 
-        true.match_or!(true => check_match = true; check_default = false);
+        true.match_or!(true => check_match = true; check_default = true);
         assert!(check_match);
-        assert!(check_default);
+        assert!(!check_default);
 
+        check_match = false;
         check_default = false;
 
-        true.match_or!(false => check_match = false; check_default = true);
-        assert!(check_match);
+        false.match_or!(true => check_match = true; check_default = true);
+        assert!(!check_match);
         assert!(check_default);
     }
 }
@@ -48,16 +49,17 @@ postfix_macros! {
     #[test]
     fn builtin_then_else() {
         let mut check_then = false;
-        let mut check_else = true;
+        let mut check_else = false;
 
-        true.then!(check_then = true).then_else!(check_else = false);
+        true.then!(check_then = true).then_else!(check_else = true);
         assert!(check_then);
-        assert!(check_else);
+        assert!(!check_else);
 
+        check_then = false;
         check_else = false;
 
-        false.then!(check_then = false).then_else!(check_else = true);
-        assert!(check_then);
+        false.then!(check_then = true).then_else!(check_else = true);
+        assert!(!check_then);
         assert!(check_else);
     }
 }


### PR DESCRIPTION
After realizing the doc test passes I'm not sure anymore whether this is actually wrong or it's intended this way? But anyway, here it goes:

```rust
use postfix_macros::{postfix_macros, then, then_else};

fn main() {
    postfix_macros! {
        for i in 0..4 {
            (i % 2 == 0)
                .then!{ println!("{} - then", i) }
                .then_else!{ println!("{} - else", i) }
        }
    }
}
```

prints

```
0 - then
0 - else
1 - else
2 - then
2 - else
3 - else
```

Since `then_else` is supposed to be the equivalent of `else` I'd expect it to only ever print `then` or `else`. Instead, the `else` case always executes. The doc test is written as if this behavior is correct but that doesn't make any sense to me. I see no reason for a postfix macro that just runs the given code?

Looking at the macro definition this behavior completely makes sense. It doesn't actually involve an `else` anywhere. It just wraps the body in a block.

Since `postfix_macros!` wraps the `self` parameter in a block we can't actually just add an `else` and need to match on `then!` instead but that's probably a good thing since it avoids misuse of the macro. And I don't think there's any reason anybody would want to use this without `postfix_macros!` anyway.

I also added some more simple tests for all the built-in macros.